### PR TITLE
Add Claude API support as alternative to OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-# OpenAI API Key for summarization
+# AI API Keys for summarization (choose one)
 OPENAI_API_KEY=your_openai_api_key_here
+CLAUDE_API_KEY=your_claude_api_key_here
 
 # Google API credentials path
 GOOGLE_CREDENTIALS_PATH=credentials.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A cross-platform, privacy-focused tool that continuously transcribes microphone 
 3. **Configure Environment**
    ```bash
    cp .env.example .env
-   # Edit .env with your OpenAI API key
+   # Edit .env with your AI API key (OpenAI or Claude)
    ```
 
 4. **Run the Application**

--- a/SETUP.md
+++ b/SETUP.md
@@ -64,8 +64,28 @@ nano .env
 ```
 
 Required environment variables:
-- `OPENAI_API_KEY`: Your OpenAI API key for summarization
+- `OPENAI_API_KEY`: Your OpenAI API key for summarization (if using OpenAI)
+- `CLAUDE_API_KEY`: Your Claude API key for summarization (if using Claude)
 - `GOOGLE_CREDENTIALS_PATH`: Path to Google Cloud credentials file (optional)
+
+Note: You only need one AI API key - either OpenAI or Claude, depending on your preference.
+
+#### AI Provider Setup
+
+**Option 1: OpenAI (GPT models)**
+1. Get an API key from [OpenAI](https://platform.openai.com/api-keys)
+2. Add to `.env`: `OPENAI_API_KEY=your_key_here`
+3. Set in config: `provider: "openai"` and `model: "gpt-3.5-turbo"`
+
+**Option 2: Claude (Anthropic)**
+1. Get an API key from [Anthropic Console](https://console.anthropic.com/)
+2. Add to `.env`: `CLAUDE_API_KEY=your_key_here`
+3. Set in config: `provider: "claude"` and `model: "claude-3-haiku-20240307"`
+
+Available Claude models:
+- `claude-3-haiku-20240307` (fastest, most cost-effective)
+- `claude-3-sonnet-20240229` (balanced performance)
+- `claude-3-opus-20240229` (highest capability)
 
 #### Google Docs Setup (Optional)
 
@@ -147,8 +167,8 @@ transcription:
   device: "auto"  # auto, cpu, cuda
 
 summary:
-  provider: "openai"
-  model: "gpt-3.5-turbo"
+  provider: "openai"  # or "claude"
+  model: "gpt-3.5-turbo"  # OpenAI: gpt-3.5-turbo, gpt-4, etc. Claude: claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229
   daily_summary: true
   summary_time: "23:00"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,9 @@ google-api-python-client>=2.100.0
 google-auth-httplib2>=0.2.0
 google-auth-oauthlib>=1.0.0
 
-# Summarization (OpenAI)
+# Summarization (AI providers)
 openai>=1.0.0
+anthropic>=0.7.0
 
 # Configuration and utilities
 PyYAML>=6.0

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for the transcription application."""
 
 import argparse
+import os
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -78,6 +79,9 @@ def cmd_test_summary(text_file: str):
         text_content = f.read()
     
     print(f"Generating summary for: {text_file}")
+    print(f"Using provider: {config.summary.provider}")
+    print(f"Using model: {config.summary.model}")
+    
     summary = summarization_service.generate_daily_summary(text_content, date.today())
     
     if summary:
@@ -154,7 +158,18 @@ def cmd_status():
     print(f"  Audio device: {config.audio.device_id or 'Default'}")
     print(f"  Transcription model: {config.transcription.model_size}")
     print(f"  Summary provider: {config.summary.provider}")
+    print(f"  Summary model: {config.summary.model}")
     print(f"  Google Docs: {'Enabled' if config.google_docs.enabled else 'Disabled'}")
+    
+    # Check API keys
+    load_environment_variables()
+    print("\nAPI Key Status:")
+    if config.summary.provider == "openai":
+        openai_key = os.getenv('OPENAI_API_KEY')
+        print(f"  OpenAI API Key: {'✅ Set' if openai_key else '❌ Missing'}")
+    elif config.summary.provider == "claude":
+        claude_key = os.getenv('CLAUDE_API_KEY')
+        print(f"  Claude API Key: {'✅ Set' if claude_key else '❌ Missing'}")
     
     # Check storage directories
     paths = config.get_storage_paths()

--- a/src/config.py
+++ b/src/config.py
@@ -33,8 +33,8 @@ class TranscriptionConfig:
 @dataclass
 class SummaryConfig:
     """Summary generation configuration."""
-    provider: str = "openai"  # openai, local
-    model: str = "gpt-3.5-turbo"
+    provider: str = "openai"  # openai, claude, local
+    model: str = "gpt-3.5-turbo"  # For OpenAI: gpt-3.5-turbo, gpt-4, etc. For Claude: claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229
     max_tokens: int = 500
     temperature: float = 0.3
     daily_summary: bool = True
@@ -155,6 +155,11 @@ def load_environment_variables() -> None:
 def get_openai_api_key() -> Optional[str]:
     """Get OpenAI API key from environment."""
     return os.getenv('OPENAI_API_KEY')
+
+
+def get_claude_api_key() -> Optional[str]:
+    """Get Claude API key from environment."""
+    return os.getenv('CLAUDE_API_KEY')
 
 
 def get_google_credentials_path() -> str:

--- a/src/summarization.py
+++ b/src/summarization.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     openai = None
 
+try:
+    import anthropic
+except ImportError:
+    anthropic = None
+
 from .config import SummaryConfig
 from .logger import LoggerMixin
 
@@ -36,10 +41,13 @@ class SummarizationService(LoggerMixin):
     
     def __init__(self, config: SummaryConfig):
         self.config = config
-        self._client: Optional[openai.OpenAI] = None
+        self._openai_client: Optional[openai.OpenAI] = None
+        self._claude_client: Optional[anthropic.Anthropic] = None
         
         if config.provider == "openai":
             self._initialize_openai()
+        elif config.provider == "claude":
+            self._initialize_claude()
         
         self.logger.info(f"SummarizationService initialized with provider: {config.provider}")
     
@@ -55,10 +63,27 @@ class SummarizationService(LoggerMixin):
             return
         
         try:
-            self._client = openai.OpenAI(api_key=api_key)
+            self._openai_client = openai.OpenAI(api_key=api_key)
             self.logger.info("OpenAI client initialized successfully")
         except Exception as e:
             self.logger.error(f"Failed to initialize OpenAI client: {e}")
+    
+    def _initialize_claude(self) -> None:
+        """Initialize Claude client."""
+        if anthropic is None:
+            self.logger.error("Anthropic package not installed. Install with: pip install anthropic")
+            return
+        
+        api_key = os.getenv('CLAUDE_API_KEY')
+        if not api_key:
+            self.logger.error("CLAUDE_API_KEY environment variable not set")
+            return
+        
+        try:
+            self._claude_client = anthropic.Anthropic(api_key=api_key)
+            self.logger.info("Claude client initialized successfully")
+        except Exception as e:
+            self.logger.error(f"Failed to initialize Claude client: {e}")
     
     def generate_daily_summary(self, transcript_text: str, date_obj: date) -> Optional[DailySummary]:
         """Generate a comprehensive daily summary from transcript text."""
@@ -103,13 +128,15 @@ class SummarizationService(LoggerMixin):
         """Analyze transcript text using AI to extract insights."""
         if self.config.provider == "openai":
             return self._analyze_with_openai(transcript_text)
+        elif self.config.provider == "claude":
+            return self._analyze_with_claude(transcript_text)
         else:
             self.logger.error(f"Unsupported summarization provider: {self.config.provider}")
             return None
     
     def _analyze_with_openai(self, transcript_text: str) -> Optional[Dict[str, Any]]:
         """Analyze transcript using OpenAI API."""
-        if not self._client:
+        if not self._openai_client:
             self.logger.error("OpenAI client not initialized")
             return None
         
@@ -117,7 +144,7 @@ class SummarizationService(LoggerMixin):
             # Create analysis prompt
             prompt = self._create_analysis_prompt(transcript_text)
             
-            response = self._client.chat.completions.create(
+            response = self._openai_client.chat.completions.create(
                 model=self.config.model,
                 messages=[
                     {
@@ -158,6 +185,55 @@ class SummarizationService(LoggerMixin):
                 
         except Exception as e:
             self.logger.error(f"Error calling OpenAI API: {e}")
+            return None
+    
+    def _analyze_with_claude(self, transcript_text: str) -> Optional[Dict[str, Any]]:
+        """Analyze transcript using Claude API."""
+        if not self._claude_client:
+            self.logger.error("Claude client not initialized")
+            return None
+        
+        try:
+            # Create analysis prompt
+            prompt = self._create_analysis_prompt(transcript_text)
+            
+            response = self._claude_client.messages.create(
+                model=self.config.model,
+                max_tokens=self.config.max_tokens,
+                temperature=self.config.temperature,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
+                ]
+            )
+            
+            # Parse the response
+            response_text = response.content[0].text.strip()
+            
+            # Try to extract JSON from the response
+            try:
+                # Look for JSON block in the response
+                if "```json" in response_text:
+                    json_start = response_text.find("```json") + 7
+                    json_end = response_text.find("```", json_start)
+                    json_text = response_text[json_start:json_end].strip()
+                else:
+                    json_text = response_text
+                
+                analysis = json.loads(json_text)
+                return analysis
+                
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Failed to parse JSON response from Claude: {e}")
+                self.logger.debug(f"Response text: {response_text}")
+                
+                # Fallback: create basic analysis
+                return self._create_fallback_analysis(transcript_text, response_text)
+                
+        except Exception as e:
+            self.logger.error(f"Error calling Claude API: {e}")
             return None
     
     def _create_analysis_prompt(self, transcript_text: str) -> str:
@@ -272,7 +348,7 @@ Respond only with valid JSON.
             # Create weekly summary text
             weekly_text = "\n".join([f"Day {i+1}: {s.summary}" for i, s in enumerate(daily_summaries)])
             
-            if self.config.provider == "openai" and self._client:
+            if self.config.provider in ["openai", "claude"] and (self._openai_client or self._claude_client):
                 weekly_analysis = self._generate_weekly_analysis(weekly_text, daily_summaries)
             else:
                 weekly_analysis = "Weekly summary of activities and conversations."
@@ -311,23 +387,40 @@ Provide a 3-4 paragraph summary covering:
 Keep it concise but insightful.
 """
             
-            response = self._client.chat.completions.create(
-                model=self.config.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "You are an expert assistant that provides insightful weekly summaries based on daily activity patterns."
-                    },
-                    {
-                        "role": "user",
-                        "content": prompt
-                    }
-                ],
-                max_tokens=400,
-                temperature=self.config.temperature
-            )
+            if self.config.provider == "openai" and self._openai_client:
+                response = self._openai_client.chat.completions.create(
+                    model=self.config.model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": "You are an expert assistant that provides insightful weekly summaries based on daily activity patterns."
+                        },
+                        {
+                            "role": "user",
+                            "content": prompt
+                        }
+                    ],
+                    max_tokens=400,
+                    temperature=self.config.temperature
+                )
+                return response.choices[0].message.content.strip()
+                
+            elif self.config.provider == "claude" and self._claude_client:
+                response = self._claude_client.messages.create(
+                    model=self.config.model,
+                    max_tokens=400,
+                    temperature=self.config.temperature,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": f"You are an expert assistant that provides insightful weekly summaries based on daily activity patterns.\n\n{prompt}"
+                        }
+                    ]
+                )
+                return response.content[0].text.strip()
             
-            return response.choices[0].message.content.strip()
+            else:
+                return "Weekly summary of activities and conversations."
             
         except Exception as e:
             self.logger.error(f"Error generating weekly analysis: {e}")

--- a/test_claude.py
+++ b/test_claude.py
@@ -1,0 +1,138 @@
+"""Test script to verify Claude integration."""
+
+import sys
+import os
+from pathlib import Path
+from datetime import date
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from src.config import SummaryConfig, load_environment_variables
+from src.summarization import SummarizationService
+from src.logger import setup_logger
+
+
+def test_claude_integration():
+    """Test Claude API integration."""
+    print("Testing Claude integration...")
+    
+    # Load environment variables
+    load_environment_variables()
+    
+    # Check if Claude API key is set
+    claude_key = os.getenv('CLAUDE_API_KEY')
+    if not claude_key:
+        print("❌ CLAUDE_API_KEY not set in environment")
+        print("Please set your Claude API key in .env file")
+        return False
+    
+    print("✅ Claude API key found")
+    
+    # Create Claude configuration
+    config = SummaryConfig(
+        provider="claude",
+        model="claude-3-haiku-20240307",  # Use fastest model for testing
+        max_tokens=200,
+        temperature=0.3
+    )
+    
+    # Initialize service
+    logger = setup_logger(level="INFO")
+    service = SummarizationService(config)
+    
+    # Test with sample transcript
+    sample_transcript = """
+    [09:00:00] Good morning everyone, let's start our team meeting.
+    [09:01:15] We need to discuss the quarterly goals and project updates.
+    [09:05:30] John mentioned that the client presentation went well yesterday.
+    [09:08:45] Sarah reported that the development is on track for next week's deadline.
+    [09:12:00] We should schedule a follow-up meeting with the marketing team.
+    [09:15:30] Action items: finalize the proposal, update the timeline, and send client feedback.
+    [09:18:00] Meeting concluded, thank you everyone.
+    """
+    
+    print("Generating summary with Claude...")
+    summary = service.generate_daily_summary(sample_transcript, date.today())
+    
+    if summary:
+        print("✅ Claude summary generation successful!")
+        print(f"Summary: {summary.summary}")
+        print(f"Key topics: {', '.join(summary.key_topics)}")
+        if summary.action_items:
+            print(f"Action items: {', '.join(summary.action_items)}")
+        print(f"Sentiment: {summary.sentiment}")
+        return True
+    else:
+        print("❌ Claude summary generation failed")
+        return False
+
+
+def test_openai_vs_claude():
+    """Compare OpenAI and Claude responses (if both keys available)."""
+    load_environment_variables()
+    
+    openai_key = os.getenv('OPENAI_API_KEY')
+    claude_key = os.getenv('CLAUDE_API_KEY')
+    
+    if not (openai_key and claude_key):
+        print("Skipping comparison - need both API keys")
+        return
+    
+    print("\n" + "="*50)
+    print("Comparing OpenAI vs Claude responses...")
+    
+    sample_text = """
+    [14:00:00] Started working on the new feature implementation.
+    [14:30:00] Had a call with the product manager about requirements.
+    [15:15:00] Reviewed code with senior developer, got good feedback.
+    [16:00:00] Fixed three bugs in the authentication system.
+    [16:45:00] Updated documentation and pushed changes to repository.
+    [17:00:00] Planned tomorrow's tasks and updated project board.
+    """
+    
+    logger = setup_logger(level="INFO")
+    
+    # Test OpenAI
+    print("\nOpenAI Response:")
+    openai_config = SummaryConfig(provider="openai", model="gpt-3.5-turbo", max_tokens=200)
+    openai_service = SummarizationService(openai_config)
+    openai_summary = openai_service.generate_daily_summary(sample_text, date.today())
+    
+    if openai_summary:
+        print(f"Summary: {openai_summary.summary}")
+        print(f"Topics: {', '.join(openai_summary.key_topics)}")
+    
+    # Test Claude
+    print("\nClaude Response:")
+    claude_config = SummaryConfig(provider="claude", model="claude-3-haiku-20240307", max_tokens=200)
+    claude_service = SummarizationService(claude_config)
+    claude_summary = claude_service.generate_daily_summary(sample_text, date.today())
+    
+    if claude_summary:
+        print(f"Summary: {claude_summary.summary}")
+        print(f"Topics: {', '.join(claude_summary.key_topics)}")
+
+
+def main():
+    """Run Claude integration tests."""
+    print("Claude Integration Test\n")
+    
+    success = test_claude_integration()
+    
+    if success:
+        test_openai_vs_claude()
+        print("\n🎉 Claude integration test completed successfully!")
+        print("\nTo use Claude in the app:")
+        print("1. Set provider: 'claude' in config.yaml")
+        print("2. Choose a model: claude-3-haiku-20240307, claude-3-sonnet-20240229, or claude-3-opus-20240229")
+        print("3. Ensure CLAUDE_API_KEY is set in your .env file")
+    else:
+        print("\n❌ Claude integration test failed")
+        return 1
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Added Claude (Anthropic) as a summarization provider option
- Updated SummaryConfig to support both OpenAI and Claude models
- Modified SummarizationService to handle both API providers
- Added Claude client initialization and API calls
- Updated requirements.txt with anthropic package
- Enhanced environment variables to support CLAUDE_API_KEY
- Updated documentation with Claude setup instructions
- Added CLI status checks for API keys
- Created test script for Claude integration
- Supports all Claude 3 models (Haiku, Sonnet, Opus)

Users can now choose between:
- OpenAI: gpt-3.5-turbo, gpt-4, etc.
- Claude: claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229

Configuration example:
summary:
  provider: 'claude'  # or 'openai' model: 'claude-3-haiku-20240307'