### PR TITLE
Fix missing Dict import in audio_capture.py

### DIFF
--- a/src/audio_capture.py
+++ b/src/audio_capture.py
@@ -7,7 +7,7 @@ import threading
 import time
 from pathlib import Path
 from datetime import datetime
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, Dict
 from queue import Queue, Empty
 from dataclasses import dataclass
 


### PR DESCRIPTION
- Add Dict to typing imports to fix NameError
- Resolves startup crash when running the application