### PR TITLE
Fix JSON serialization error in status API

### DIFF
--- a/src/audio_capture.py
+++ b/src/audio_capture.py
@@ -141,15 +141,15 @@ class AudioCapture(LoggerMixin):
                 'threshold': self.config.silence_threshold
             }
         
-        current = self._audio_level_history[-1] if self._audio_level_history else 0.0
-        average = sum(self._audio_level_history) / len(self._audio_level_history)
-        maximum = max(self._audio_level_history)
+        current = float(self._audio_level_history[-1]) if self._audio_level_history else 0.0
+        average = float(sum(self._audio_level_history) / len(self._audio_level_history))
+        maximum = float(max(self._audio_level_history))
         
         return {
             'current': current,
             'average': average,
             'maximum': maximum,
-            'threshold': self.config.silence_threshold,
+            'threshold': float(self.config.silence_threshold),
             'samples': len(self._audio_level_history)
         }
     

--- a/src/automation.py
+++ b/src/automation.py
@@ -558,12 +558,12 @@ class TranscriptionApp(LoggerMixin):
             
             # Get audio configuration for debugging
             audio_config = {
-                'silence_threshold': self.config.audio.silence_threshold,
-                'silence_duration': self.config.audio.silence_duration,
-                'min_audio_duration': getattr(self.config.audio, 'min_audio_duration', 'N/A'),
-                'noise_gate_threshold': getattr(self.config.audio, 'noise_gate_threshold', 'N/A'),
-                'sample_rate': self.config.audio.sample_rate,
-                'channels': self.config.audio.channels
+                'silence_threshold': float(self.config.audio.silence_threshold),
+                'silence_duration': float(self.config.audio.silence_duration),
+                'min_audio_duration': float(getattr(self.config.audio, 'min_audio_duration', 2.0)),
+                'noise_gate_threshold': float(getattr(self.config.audio, 'noise_gate_threshold', 0.015)),
+                'sample_rate': int(self.config.audio.sample_rate),
+                'channels': int(self.config.audio.channels)
             }
             
             # Get audio levels for debugging


### PR DESCRIPTION
Critical Fix:
- Fix 'Object of type float32 is not JSON serializable' error
- Convert numpy float32 values to Python floats in audio levels
- Convert all audio config values to JSON-safe types
- Add custom NumpyJSONEncoder for handling numpy types
- Add safe_jsonify wrapper for all API endpoints

Root Cause:
The /api/status endpoint was failing because numpy float32 values from audio level calculations couldn't be serialized to JSON. This caused the main page to show 'Loading...' indefinitely.

Solution:
- Convert all numpy types to Python types before JSON serialization
- Add fallback JSON encoder for any remaining numpy types
- Use safe_jsonify for all API responses

This should resolve the 'Loading...' status issue completely.