### PR TITLE
Fix recording sensitivity and automated summary/Google Docs errors + Add comprehensive linter and test suite

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,33 @@
+[flake8]
+max-line-length = 120
+exclude = 
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    env,
+    build,
+    dist,
+    *.egg-info,
+    .eggs,
+    transcripts,
+    backups
+
+# Ignore specific error codes
+ignore = 
+    E203,
+    E501,
+    W503,
+    W504
+
+per-file-ignores =
+    __init__.py:F401
+
+# Show source code for errors
+show-source = True
+
+# Count errors
+count = True
+
+# Show statistics
+statistics = True

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,83 @@
+[MASTER]
+# Use multiple processes to speed up Pylint
+jobs=0
+
+# Pickle collected data for later comparisons
+persistent=yes
+
+# List of plugins (as comma separated values of python module names)
+load-plugins=
+
+# Ignore patterns
+ignore=CVS,.git,__pycache__,.venv,venv,env,transcripts,backups
+
+[MESSAGES CONTROL]
+# Disable specific warnings
+disable=
+    C0111,  # missing-docstring
+    C0103,  # invalid-name
+    R0903,  # too-few-public-methods
+    R0913,  # too-many-arguments
+    R0914,  # too-many-locals
+    W0212,  # protected-access
+    W0511,  # fixme
+    C0301,  # line-too-long (handled by max-line-length)
+
+[FORMAT]
+# Maximum number of characters on a single line
+max-line-length=120
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit
+indent-string='    '
+
+[BASIC]
+# Good variable names
+good-names=i,j,k,ex,Run,_,id,db,f,e
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,50}$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,50}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+[DESIGN]
+# Maximum number of arguments for function / method
+max-args=10
+
+# Maximum number of attributes for a class
+max-attributes=15
+
+# Maximum number of boolean expressions in an if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=15
+
+# Maximum number of locals for function / method body
+max-locals=20
+
+# Maximum number of parents for a class
+max-parents=7
+
+# Maximum number of public methods for a class
+max-public-methods=25
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=60
+
+[IMPORTS]
+# Allow wildcard imports from modules
+allow-wildcard-with-all=no
+
+[EXCEPTIONS]
+# Exceptions that will emit a warning when caught
+overgeneral-exceptions=builtins.Exception

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+.PHONY: help install test lint format clean all
+
+help:
+	@echo "Available commands:"
+	@echo "  make install    - Install dependencies"
+	@echo "  make test       - Run tests with pytest"
+	@echo "  make lint       - Run linters (flake8, pylint)"
+	@echo "  make format     - Format code with black and isort"
+	@echo "  make clean      - Clean up generated files"
+	@echo "  make all        - Format, lint, and test"
+
+install:
+	pip install -r requirements.txt
+
+test:
+	pytest tests/ -v --tb=short
+
+test-cov:
+	pytest tests/ -v --cov=src --cov-report=html --cov-report=term
+
+lint:
+	@echo "Running flake8..."
+	flake8 src/ tests/
+	@echo "Running pylint..."
+	pylint src/ --exit-zero
+
+format:
+	@echo "Running isort..."
+	isort src/ tests/
+	@echo "Running black..."
+	black src/ tests/
+
+format-check:
+	@echo "Checking isort..."
+	isort --check-only src/ tests/
+	@echo "Checking black..."
+	black --check src/ tests/
+
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".mypy_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "htmlcov" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete
+	find . -type f -name ".coverage" -delete
+
+all: format lint test
+	@echo "All checks passed!"

--- a/config_test.yaml
+++ b/config_test.yaml
@@ -4,7 +4,9 @@ audio:
   chunk_duration: 30  # 30 seconds for testing (instead of 5 minutes)
   device_id: null
   silence_threshold: 0.02  # Higher threshold to avoid false silence detection
-  silence_duration: 5.0    # Longer silence before segmenting
+  silence_duration: 5.0    # Longer silence before segmenting (keeps natural pauses in one file)
+  min_audio_duration: 3.0  # Minimum 3 seconds to filter out very short clips
+  noise_gate_threshold: 0.015  # Additional noise gate threshold
 
 transcription:
   provider: "local"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,68 @@
+[tool.black]
+line-length = 120
+target-version = ['py38', 'py39', 'py310', 'py311']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | venv
+  | env
+  | _build
+  | buck-out
+  | build
+  | dist
+  | transcripts
+  | backups
+)/
+'''
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--tb=short",
+    "--disable-warnings",
+]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 120
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+skip_glob = ["*/transcripts/*", "*/backups/*", "*/.venv/*", "*/venv/*"]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+exclude = [
+    "transcripts",
+    "backups",
+    ".venv",
+    "venv",
+]
+
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,10 @@ waitress>=2.1.0  # Production WSGI server
 
 # Development dependencies
 pytest>=6.0.0
+pytest-cov>=3.0.0
+pytest-mock>=3.6.0
 black>=22.0.0
 flake8>=4.0.0
+pylint>=2.12.0
+isort>=5.10.0
+mypy>=0.950

--- a/src/config.py
+++ b/src/config.py
@@ -16,8 +16,8 @@ class AudioConfig:
     format: str = "wav"
     device_id: Optional[int] = None
     silence_threshold: float = 0.02  # Moderate increase from 0.01 to reduce ambient noise sensitivity
-    silence_duration: float = 2.5  # Slightly increased from 2.0 seconds for better noise filtering
-    min_audio_duration: float = 1.5  # Minimum duration for audio segments to be processed
+    silence_duration: float = 5.0  # Increased to 5 seconds to keep natural pauses in one file
+    min_audio_duration: float = 3.0  # Minimum 3 seconds to filter out very short clips
     noise_gate_threshold: float = 0.015  # Additional noise gate threshold (lower than silence_threshold)
 
 

--- a/src/google_docs.py
+++ b/src/google_docs.py
@@ -114,23 +114,14 @@ class GoogleDocsService(LoggerMixin):
             
             self._credentials = creds
             
-            # Create HTTP client with SSL configuration
-            http_client = self._create_http_client()
-            
-            # Build service objects with custom HTTP client
+            # Build service objects - use default client (credentials parameter handles auth)
+            # Note: http and credentials parameters are mutually exclusive
             try:
-                if http_client:
-                    self._docs_service = build('docs', 'v1', credentials=creds, http=http_client)
-                    self._drive_service = build('drive', 'v3', credentials=creds, http=http_client)
-                else:
-                    # Fallback to default
-                    self._docs_service = build('docs', 'v1', credentials=creds)
-                    self._drive_service = build('drive', 'v3', credentials=creds)
-            except Exception as ssl_error:
-                self.logger.warning(f"SSL error with custom client, trying default: {ssl_error}")
-                # Fallback to default client
                 self._docs_service = build('docs', 'v1', credentials=creds)
                 self._drive_service = build('drive', 'v3', credentials=creds)
+            except Exception as build_error:
+                self.logger.error(f"Error building Google API services: {build_error}")
+                return False
             
             self.logger.info("Google APIs authenticated successfully")
             return True

--- a/src/summarization.py
+++ b/src/summarization.py
@@ -298,7 +298,7 @@ Respond only with valid JSON.
 """
         return prompt
     
-    def _create_fallback_analysis(self, transcript_text: str, ai_response: str) -> Dict[str, Any]:
+    def _create_fallback_analysis(self, transcript_text: str, ai_response: str = "") -> Dict[str, Any]:
         """Create a basic analysis when AI parsing fails."""
         words = transcript_text.split()
         word_count = len(words)
@@ -316,8 +316,14 @@ Respond only with valid JSON.
         top_words = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:10]
         key_topics = [word for word, freq in top_words if freq > 1]
         
+        # Use AI response if available, otherwise create generic summary
+        if ai_response:
+            summary_text = ai_response[:200] + "..." if len(ai_response) > 200 else ai_response
+        else:
+            summary_text = f"Daily transcript containing {word_count} words covering various topics and conversations."
+        
         return {
-            "summary": ai_response[:200] + "..." if len(ai_response) > 200 else ai_response,
+            "summary": summary_text,
             "summary_first_person": "I had various conversations and activities today. The transcript contains my daily interactions and thoughts.",
             "key_topics": key_topics[:5],
             "action_items": [],

--- a/src/summarization.py
+++ b/src/summarization.py
@@ -497,31 +497,3 @@ Keep it concise but insightful.
         except Exception as e:
             self.logger.error(f"Error loading summary from {summary_path}: {e}")
             return None
-    
-    def _create_fallback_analysis(self, transcript_text: str) -> Dict[str, Any]:
-        """Create a basic analysis when AI services are not available."""
-        words = transcript_text.split()
-        sentences = transcript_text.split('.')
-        
-        # Extract some basic keywords (simple approach)
-        common_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by', 'is', 'are', 'was', 'were', 'be', 'been', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could', 'should', 'may', 'might', 'can', 'this', 'that', 'these', 'those', 'i', 'you', 'he', 'she', 'it', 'we', 'they', 'me', 'him', 'her', 'us', 'them'}
-        
-        word_freq = {}
-        for word in words:
-            clean_word = word.lower().strip('.,!?;:"()[]{}')
-            if len(clean_word) > 3 and clean_word not in common_words:
-                word_freq[clean_word] = word_freq.get(clean_word, 0) + 1
-        
-        # Get top keywords
-        key_topics = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:5]
-        key_topics = [word for word, count in key_topics]
-        
-        return {
-            'summary': f"Daily transcript containing {len(words)} words across {len(sentences)} sentences. Key topics discussed include: {', '.join(key_topics[:3])}.",
-            'summary_first_person': "I had various conversations and activities today. The transcript contains my daily interactions and thoughts.",
-            'key_topics': key_topics,
-            'action_items': [],
-            'meetings': [],
-            'sentiment': 'neutral',
-            'estimated_duration': len(words) * 0.5 / 60  # Rough estimate: 0.5 seconds per word
-        }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,86 @@
+# Test Suite
+
+This directory contains the test suite for the transcription and summary application.
+
+## Running Tests
+
+### Run all tests
+```bash
+pytest tests/
+```
+
+### Run with verbose output
+```bash
+pytest tests/ -v
+```
+
+### Run with coverage report
+```bash
+pytest tests/ --cov=src --cov-report=html
+```
+
+### Run specific test file
+```bash
+pytest tests/test_config.py
+```
+
+### Run specific test
+```bash
+pytest tests/test_config.py::TestAudioConfig::test_default_values
+```
+
+## Test Structure
+
+- `conftest.py` - Pytest configuration and shared fixtures
+- `test_config.py` - Tests for configuration module
+- `test_audio_capture.py` - Tests for audio capture functionality
+- `test_summarization.py` - Tests for summarization service
+
+## Fixtures
+
+Common fixtures available in all tests (defined in `conftest.py`):
+
+- `temp_dir` - Temporary directory for test files
+- `test_config` - Test configuration with safe defaults
+- `sample_transcript_text` - Sample transcript for testing
+- `sample_audio_data` - Generated audio data for testing
+- `mock_audio_segment` - Mock audio segment with test file
+
+## Writing New Tests
+
+1. Create a new file `test_<module_name>.py`
+2. Import the module you want to test
+3. Create test classes with `Test` prefix
+4. Create test methods with `test_` prefix
+5. Use fixtures from `conftest.py` or create new ones
+
+Example:
+```python
+import pytest
+from src.my_module import MyClass
+
+class TestMyClass:
+    def test_something(self, test_config):
+        obj = MyClass(test_config)
+        assert obj.do_something() == expected_result
+```
+
+## Test Markers
+
+Use markers to categorize tests:
+
+```python
+@pytest.mark.slow
+def test_long_running_operation():
+    pass
+
+@pytest.mark.integration
+def test_api_integration():
+    pass
+```
+
+Run specific markers:
+```bash
+pytest -m "not slow"  # Skip slow tests
+pytest -m integration  # Run only integration tests
+```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for transcription and summary application."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,126 @@
+"""Pytest configuration and fixtures."""
+
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+from datetime import datetime, date
+
+from src.config import (
+    AppConfig,
+    AudioConfig,
+    TranscriptionConfig,
+    SummaryConfig,
+    GoogleDocsConfig,
+    StorageConfig,
+    UIConfig,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests."""
+    temp_path = Path(tempfile.mkdtemp())
+    yield temp_path
+    # Cleanup after test
+    if temp_path.exists():
+        shutil.rmtree(temp_path)
+
+
+@pytest.fixture
+def test_config(temp_dir):
+    """Create a test configuration."""
+    config = AppConfig(
+        audio=AudioConfig(
+            sample_rate=16000,
+            channels=1,
+            chunk_duration=30,
+            silence_threshold=0.02,
+            silence_duration=5.0,
+            min_audio_duration=3.0,
+        ),
+        transcription=TranscriptionConfig(
+            provider="local",
+            model_size="tiny",
+            language="en",
+        ),
+        summary=SummaryConfig(
+            provider="openai",
+            model="gpt-3.5-turbo",
+            daily_summary=False,  # Disable for tests
+        ),
+        google_docs=GoogleDocsConfig(
+            enabled=False,  # Disable for tests
+        ),
+        storage=StorageConfig(
+            base_dir=str(temp_dir),
+            audio_dir="audio",
+            transcript_dir="transcripts",
+            summary_dir="summaries",
+            backup_dir="backups",
+        ),
+        ui=UIConfig(
+            system_tray=False,
+            web_dashboard=False,
+        ),
+        debug=True,
+        log_level="DEBUG",
+    )
+    config.ensure_directories()
+    return config
+
+
+@pytest.fixture
+def sample_transcript_text():
+    """Sample transcript text for testing."""
+    return """[10:30:15] Good morning, I need to schedule a meeting with the team.
+[10:31:22] Let's discuss the project timeline and deliverables.
+[10:32:45] I should also follow up with the client about their feedback.
+[10:35:10] The presentation needs to be ready by Friday.
+[10:36:30] Don't forget to review the budget proposal."""
+
+
+@pytest.fixture
+def sample_audio_data():
+    """Generate sample audio data for testing."""
+    import numpy as np
+
+    sample_rate = 16000
+    duration = 3  # 3 seconds
+    frequency = 440  # A4 note
+
+    t = np.linspace(0, duration, int(sample_rate * duration))
+    audio_data = np.sin(2 * np.pi * frequency * t) * 0.3
+
+    return audio_data.astype(np.float32)
+
+
+@pytest.fixture
+def mock_audio_segment(temp_dir):
+    """Create a mock audio segment for testing."""
+    from src.audio_capture import AudioSegment
+    import wave
+    import numpy as np
+
+    # Create a test audio file
+    audio_file = temp_dir / "test_audio.wav"
+    sample_rate = 16000
+    duration = 3
+
+    # Generate simple audio
+    t = np.linspace(0, duration, int(sample_rate * duration))
+    audio_data = (np.sin(2 * np.pi * 440 * t) * 0.3 * 32767).astype(np.int16)
+
+    with wave.open(str(audio_file), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(audio_data.tobytes())
+
+    return AudioSegment(
+        file_path=audio_file,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        duration=duration,
+        sample_rate=sample_rate,
+    )

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -1,0 +1,153 @@
+"""Tests for audio capture module."""
+
+import pytest
+import numpy as np
+from pathlib import Path
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+# Mock sounddevice before importing audio_capture
+import sys
+sys.modules['sounddevice'] = Mock()
+
+from src.audio_capture import AudioCapture, AudioSegment
+from src.config import AudioConfig
+
+
+class TestAudioSegment:
+    """Tests for AudioSegment dataclass."""
+
+    def test_audio_segment_creation(self, temp_dir):
+        """Test creating an AudioSegment."""
+        audio_file = temp_dir / "test.wav"
+        audio_file.touch()
+
+        segment = AudioSegment(
+            file_path=audio_file,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            duration=5.0,
+            sample_rate=16000,
+        )
+
+        assert segment.file_path == audio_file
+        assert segment.duration == 5.0
+        assert segment.sample_rate == 16000
+
+
+class TestAudioCapture:
+    """Tests for AudioCapture class."""
+
+    def test_initialization(self, temp_dir):
+        """Test AudioCapture initialization."""
+        config = AudioConfig()
+        capture = AudioCapture(config, temp_dir)
+
+        assert capture.config == config
+        assert capture.output_dir == temp_dir
+        assert not capture.is_recording()
+
+    def test_output_directory_creation(self, temp_dir):
+        """Test that output directory is created."""
+        output_dir = temp_dir / "audio_output"
+        config = AudioConfig()
+        capture = AudioCapture(config, output_dir)
+
+        assert output_dir.exists()
+        assert output_dir.is_dir()
+
+    def test_silence_detection_parameters(self, temp_dir):
+        """Test silence detection configuration."""
+        config = AudioConfig(
+            silence_threshold=0.03, silence_duration=7.0, min_audio_duration=4.0
+        )
+        capture = AudioCapture(config, temp_dir)
+
+        assert capture.config.silence_threshold == 0.03
+        assert capture.config.silence_duration == 7.0
+        assert capture.config.min_audio_duration == 4.0
+
+    def test_has_sufficient_audio_content(self, temp_dir):
+        """Test audio content quality check."""
+        config = AudioConfig(silence_threshold=0.02, noise_gate_threshold=0.015)
+        capture = AudioCapture(config, temp_dir)
+
+        # Create audio with sufficient content
+        sample_rate = 16000
+        duration = 3
+        t = np.linspace(0, duration, int(sample_rate * duration))
+        loud_audio = (np.sin(2 * np.pi * 440 * t) * 0.3).astype(np.float32)
+
+        assert capture._has_sufficient_audio_content(loud_audio)
+
+        # Create audio with insufficient content (too quiet)
+        quiet_audio = (np.sin(2 * np.pi * 440 * t) * 0.001).astype(np.float32)
+        assert not capture._has_sufficient_audio_content(quiet_audio)
+
+    def test_callback_registration(self, temp_dir):
+        """Test segment callback registration."""
+        config = AudioConfig()
+        capture = AudioCapture(config, temp_dir)
+
+        callback_called = []
+
+        def test_callback(segment):
+            callback_called.append(segment)
+
+        capture.set_segment_callback(test_callback)
+        assert capture._on_segment_complete is not None
+
+    def test_audio_levels_tracking(self, temp_dir):
+        """Test audio level monitoring."""
+        config = AudioConfig()
+        capture = AudioCapture(config, temp_dir)
+
+        levels = capture.get_audio_levels()
+
+        assert "current" in levels
+        assert "average" in levels
+        assert "maximum" in levels
+        assert "threshold" in levels
+        assert levels["threshold"] == config.silence_threshold
+
+    def test_pause_resume(self, temp_dir):
+        """Test pause and resume functionality."""
+        config = AudioConfig()
+        capture = AudioCapture(config, temp_dir)
+
+        # Initially not paused
+        assert not capture._paused
+
+        # Pause
+        capture.pause_recording()
+        assert capture._paused
+
+        # Resume
+        capture.resume_recording()
+        assert not capture._paused
+
+
+class TestAudioProcessing:
+    """Tests for audio processing functions."""
+
+    def test_minimum_duration_filter(self, temp_dir):
+        """Test that short audio segments are filtered out."""
+        config = AudioConfig(min_audio_duration=3.0)
+        capture = AudioCapture(config, temp_dir)
+
+        # Create short audio (1 second)
+        sample_rate = 16000
+        short_audio = np.random.randn(sample_rate).astype(np.float32) * 0.1
+
+        # This should be filtered out due to duration
+        duration = len(short_audio) / sample_rate
+        assert duration < config.min_audio_duration
+
+    def test_silence_duration_threshold(self, temp_dir):
+        """Test silence duration threshold."""
+        config = AudioConfig(silence_duration=5.0)
+        capture = AudioCapture(config, temp_dir)
+
+        assert config.silence_duration == 5.0
+        # This ensures natural pauses (2-4 seconds) don't trigger new files
+        assert config.silence_duration > 4.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,155 @@
+"""Tests for configuration module."""
+
+import pytest
+from pathlib import Path
+import yaml
+
+from src.config import (
+    AppConfig,
+    AudioConfig,
+    TranscriptionConfig,
+    SummaryConfig,
+    GoogleDocsConfig,
+    StorageConfig,
+    UIConfig,
+)
+
+
+class TestAudioConfig:
+    """Tests for AudioConfig."""
+
+    def test_default_values(self):
+        """Test default audio configuration values."""
+        config = AudioConfig()
+        assert config.sample_rate == 16000
+        assert config.channels == 1
+        assert config.silence_duration == 5.0
+        assert config.min_audio_duration == 3.0
+        assert config.silence_threshold == 0.02
+
+    def test_custom_values(self):
+        """Test custom audio configuration values."""
+        config = AudioConfig(
+            sample_rate=44100,
+            channels=2,
+            silence_duration=10.0,
+            min_audio_duration=5.0,
+        )
+        assert config.sample_rate == 44100
+        assert config.channels == 2
+        assert config.silence_duration == 10.0
+        assert config.min_audio_duration == 5.0
+
+
+class TestAppConfig:
+    """Tests for AppConfig."""
+
+    def test_default_config_creation(self):
+        """Test creating default configuration."""
+        config = AppConfig(
+            audio=AudioConfig(),
+            transcription=TranscriptionConfig(),
+            summary=SummaryConfig(),
+            google_docs=GoogleDocsConfig(),
+            storage=StorageConfig(),
+            ui=UIConfig(),
+        )
+        assert config.audio is not None
+        assert config.transcription is not None
+        assert config.summary is not None
+        assert config.google_docs is not None
+        assert config.storage is not None
+        assert config.ui is not None
+
+    def test_save_and_load_config(self, temp_dir):
+        """Test saving and loading configuration."""
+        config_path = temp_dir / "test_config.yaml"
+
+        # Create and save config
+        original_config = AppConfig(
+            audio=AudioConfig(sample_rate=44100),
+            transcription=TranscriptionConfig(model_size="base"),
+            summary=SummaryConfig(provider="claude"),
+            google_docs=GoogleDocsConfig(enabled=False),
+            storage=StorageConfig(base_dir=str(temp_dir)),
+            ui=UIConfig(web_port=9090),
+        )
+        original_config.save(str(config_path))
+
+        # Load config
+        assert config_path.exists()
+        loaded_config = AppConfig.load(str(config_path))
+
+        # Verify values
+        assert loaded_config.audio.sample_rate == 44100
+        assert loaded_config.transcription.model_size == "base"
+        assert loaded_config.summary.provider == "claude"
+        assert loaded_config.google_docs.enabled is False
+        assert loaded_config.ui.web_port == 9090
+
+    def test_get_storage_paths(self, test_config):
+        """Test getting storage paths."""
+        paths = test_config.get_storage_paths()
+
+        assert "base" in paths
+        assert "audio" in paths
+        assert "transcripts" in paths
+        assert "summaries" in paths
+        assert "backups" in paths
+
+        assert isinstance(paths["base"], Path)
+        assert isinstance(paths["audio"], Path)
+
+    def test_ensure_directories(self, test_config):
+        """Test directory creation."""
+        test_config.ensure_directories()
+
+        paths = test_config.get_storage_paths()
+        for path in paths.values():
+            assert path.exists()
+            assert path.is_dir()
+
+
+class TestTranscriptionConfig:
+    """Tests for TranscriptionConfig."""
+
+    def test_default_provider(self):
+        """Test default transcription provider."""
+        config = TranscriptionConfig()
+        assert config.provider == "local"
+        assert config.model_size == "base"
+        assert config.language == "en"
+
+    def test_custom_provider(self):
+        """Test custom transcription provider."""
+        config = TranscriptionConfig(
+            provider="openai_api", model_size="large", language="es"
+        )
+        assert config.provider == "openai_api"
+        assert config.model_size == "large"
+        assert config.language == "es"
+
+
+class TestSummaryConfig:
+    """Tests for SummaryConfig."""
+
+    def test_default_values(self):
+        """Test default summary configuration."""
+        config = SummaryConfig()
+        assert config.provider == "openai"
+        assert config.model == "gpt-3.5-turbo"
+        assert config.daily_summary is True
+        assert config.summary_time == "23:00"
+
+    def test_custom_values(self):
+        """Test custom summary configuration."""
+        config = SummaryConfig(
+            provider="claude",
+            model="claude-3-sonnet-20240229",
+            daily_summary=False,
+            hourly_summary=True,
+        )
+        assert config.provider == "claude"
+        assert config.model == "claude-3-sonnet-20240229"
+        assert config.daily_summary is False
+        assert config.hourly_summary is True

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,0 +1,206 @@
+"""Tests for summarization module."""
+
+import pytest
+from datetime import date
+from unittest.mock import Mock, patch
+
+from src.summarization import SummarizationService, DailySummary
+from src.config import SummaryConfig
+
+
+class TestSummarizationService:
+    """Tests for SummarizationService."""
+
+    def test_initialization(self):
+        """Test service initialization."""
+        config = SummaryConfig(provider="openai")
+        service = SummarizationService(config)
+
+        assert service.config == config
+        assert service.config.provider == "openai"
+
+    def test_fallback_analysis_with_response(self):
+        """Test fallback analysis with AI response."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        transcript = "This is a test transcript with some important keywords like meeting, project, and deadline."
+        ai_response = "This is a summary from the AI."
+
+        analysis = service._create_fallback_analysis(transcript, ai_response)
+
+        assert "summary" in analysis
+        assert "key_topics" in analysis
+        assert "action_items" in analysis
+        assert "sentiment" in analysis
+        assert analysis["summary"] == ai_response
+        assert isinstance(analysis["key_topics"], list)
+
+    def test_fallback_analysis_without_response(self):
+        """Test fallback analysis without AI response."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        transcript = "This is a test transcript with some important keywords like meeting, project, and deadline."
+
+        analysis = service._create_fallback_analysis(transcript)
+
+        assert "summary" in analysis
+        assert "key_topics" in analysis
+        assert len(analysis["summary"]) > 0
+        assert "words" in analysis["summary"]
+
+    def test_fallback_analysis_keyword_extraction(self):
+        """Test keyword extraction in fallback analysis."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        transcript = """
+        meeting meeting meeting project project deadline
+        important important discussion discussion team team
+        """
+
+        analysis = service._create_fallback_analysis(transcript)
+
+        # Should extract repeated keywords
+        assert len(analysis["key_topics"]) > 0
+        # Common words should be filtered out
+        assert "the" not in analysis["key_topics"]
+        assert "and" not in analysis["key_topics"]
+
+    def test_create_analysis_prompt(self):
+        """Test analysis prompt creation."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        transcript = "Test transcript content"
+        prompt = service._create_analysis_prompt(transcript)
+
+        assert "Test transcript content" in prompt
+        assert "JSON" in prompt
+        assert "summary" in prompt.lower()
+        assert "key_topics" in prompt.lower()
+        assert "action_items" in prompt.lower()
+
+    def test_prompt_truncation(self):
+        """Test that long transcripts are truncated in prompts."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        # Create a very long transcript
+        long_transcript = "word " * 10000
+        prompt = service._create_analysis_prompt(long_transcript)
+
+        # Should be truncated
+        assert "[truncated]" in prompt
+        assert len(prompt) < len(long_transcript)
+
+
+class TestDailySummary:
+    """Tests for DailySummary dataclass."""
+
+    def test_daily_summary_creation(self):
+        """Test creating a DailySummary."""
+        summary = DailySummary(
+            date=date.today(),
+            total_duration=120.0,
+            word_count=500,
+            key_topics=["meeting", "project", "deadline"],
+            summary="Daily summary text",
+            summary_first_person="I had a productive day",
+            action_items=["Follow up with team", "Review documents"],
+            meetings=[{"title": "Team Standup", "participants": ["Alice", "Bob"]}],
+            sentiment="positive",
+            created_at=None,
+            transcript_files=[],
+        )
+
+        assert summary.word_count == 500
+        assert len(summary.key_topics) == 3
+        assert len(summary.action_items) == 2
+        assert summary.sentiment == "positive"
+
+
+class TestSummaryGeneration:
+    """Tests for summary generation functionality."""
+
+    def test_generate_daily_summary_empty_transcript(self):
+        """Test handling of empty transcript."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        result = service.generate_daily_summary("", date.today())
+        assert result is None
+
+    def test_generate_daily_summary_with_content(self):
+        """Test summary generation with actual content."""
+        config = SummaryConfig(provider="openai")
+        service = SummarizationService(config)
+
+        transcript = """
+        [10:00] Good morning team, let's start our standup meeting.
+        [10:05] I completed the user authentication feature yesterday.
+        [10:10] Today I'll work on the database optimization.
+        [10:15] I need help with the API integration.
+        """
+
+        # Mock the AI analysis to avoid actual API calls
+        with patch.object(service, "_analyze_transcript") as mock_analyze:
+            mock_analyze.return_value = {
+                "summary": "Team standup discussing progress and tasks",
+                "summary_first_person": "I discussed my progress with the team",
+                "key_topics": ["standup", "authentication", "database", "API"],
+                "action_items": ["Complete database optimization", "Get help with API"],
+                "meetings": [{"title": "Standup", "participants": ["team"]}],
+                "sentiment": "positive",
+                "estimated_duration": 15.0,
+            }
+
+            summary = service.generate_daily_summary(transcript, date.today())
+
+            assert summary is not None
+            assert summary.word_count > 0
+            assert len(summary.key_topics) > 0
+            assert summary.sentiment == "positive"
+
+    def test_weekly_summary_generation(self):
+        """Test weekly summary generation."""
+        config = SummaryConfig()
+        service = SummarizationService(config)
+
+        # Create sample daily summaries
+        daily_summaries = [
+            DailySummary(
+                date=date.today(),
+                total_duration=120.0,
+                word_count=500,
+                key_topics=["meeting", "project"],
+                summary="Day 1 summary",
+                summary_first_person="I had meetings",
+                action_items=["Task 1"],
+                meetings=[],
+                sentiment="positive",
+                created_at=None,
+                transcript_files=[],
+            ),
+            DailySummary(
+                date=date.today(),
+                total_duration=90.0,
+                word_count=400,
+                key_topics=["project", "deadline"],
+                summary="Day 2 summary",
+                summary_first_person="I worked on the project",
+                action_items=["Task 2"],
+                meetings=[],
+                sentiment="neutral",
+                created_at=None,
+                transcript_files=[],
+            ),
+        ]
+
+        weekly = service.generate_weekly_summary(daily_summaries)
+
+        assert weekly is not None
+        assert weekly["total_words"] == 900
+        assert weekly["daily_count"] == 2
+        assert "project" in weekly["top_topics"]


### PR DESCRIPTION
- Increase silence_duration from 2.5s to 5.0s to keep natural pauses in one file
- Increase min_audio_duration from 1.5s to 3.0s to filter out very short clips
- Fix _create_fallback_analysis() signature to accept optional ai_response parameter
- Fix Google Docs authentication by removing mutually exclusive http/credentials args
- Update config_test.yaml with new audio parameters


- Add flake8, pylint, black, and isort configuration
- Create pytest test suite with 30 unit tests
- Add test fixtures and conftest for shared test utilities
- Add Makefile for easy test/lint/format commands
- Update requirements.txt with dev dependencies (pytest-cov, pytest-mock, pylint, isort, mypy)
- Remove duplicate _create_fallback_analysis method in summarization.py
- Add tests for config, audio_capture, and summarization modules
- All 30 tests passing

Usage:
  make test       - Run all tests
  make lint       - Run linters
  make format     - Format code
  make all        - Format, lint, and test

